### PR TITLE
Fix extension manifest

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -154,7 +154,8 @@
       "aiCodingAssistantContainer": [
         {
           "id": "aiCodingAssistant.chatView",
-          "name": "Chat"
+          "name": "Chat",
+          "type": "webview"
         }
       ]
     },


### PR DESCRIPTION
Fix extension manifest to prevent "There is no data provider registered that can provide view data" error.

Similar problem: https://stackoverflow.com/questions/78598053/vscode-extension-there-is-no-data-provider-registered-that-can-provide-view-dat/79760786#79760786